### PR TITLE
- rename Traefik network to the previous one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,8 @@ CERTS_DIRECTORY := ./traefik/certs
 DOMAIN := *.${TLD}
 CERT_FILENAME := _wildcard.${TLD}.pem
 KEY_FILENAME := _wildcard.${TLD}-key.pem
-TRAEFIK_NETWORK_NAME := traefik-proxy-${TLD}
+
+TRAEFIK_NETWORK_NAME := traefik-proxy-blumilk-local
 
 export COMPOSE_DOCKER_CLI_BUILD = 1
 export DOCKER_BUILDKIT = 1


### PR DESCRIPTION
This PR roles  back Traefik network to the previous name `traefik-proxy-blumilk-local`.

Containers wont work with current network `traefik-proxy-blumilk.localhost` without manually network name change in each project.