### PR TITLE
add support for self-signed certs in trust store in containers

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -70,7 +70,7 @@ tasks:
       - cmd: docker cp {{ .CA_CERT_DIR }}/rootCA.pem {{ .CONTAINER_NAME }}:{{ .DESTINATION_DIR }}/{{ .CERT_NAME }}
       - echo "Done"
       - echo "Adding mkcert to trust store in container"
-      - cmd: docker exec --user root {{ .CONTAINER_NAME }} sh {{ .DESTINATION_DIR }}/{{ .SCRIPT_FILENAME }}
+      - cmd: docker exec --user root --workdir {{ .DESTINATION_DIR }} {{ .CONTAINER_NAME }} sh {{ .SCRIPT_FILENAME }}
       - echo "Done"
 
   generate-certs:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -51,6 +51,28 @@ tasks:
       - cmd: docker cp {{ .CA_CERT_DIR }}/rootCA.pem {{ .CONTAINER_NAME }}:/usr/local/share/ca-certificates/mkcert-ca-cert.crt
       - cmd: docker exec --user root {{ .CONTAINER_NAME }} update-ca-certificates
 
+  copy-ca-cert-to-trust-store-in-container:
+    desc: "Copy and install mkcert CA certificate to the trust store in container"
+    requires:
+      vars: [ CONTAINER_NAME ]
+    vars:
+      CA_CERT_DIR:
+        sh: "{{ .MKCERT_BINARY }} -CAROOT"
+      CERT_NAME: "blumilk-environment-mkcert-root-ca-cert.pem"
+      SCRIPT_FILENAME: "add-ca-to-trust-store.sh"
+      DESTINATION_DIR: "/tmp/blumilk-environment"
+    cmds:
+      - echo "Copying {{ .SCRIPT_FILENAME }} to the container"
+      - cmd: docker exec {{ .CONTAINER_NAME }} mkdir --parents {{ .DESTINATION_DIR }}
+      - cmd: docker cp ./scripts/{{ .SCRIPT_FILENAME }} {{ .CONTAINER_NAME }}:{{ .DESTINATION_DIR }}/{{ .SCRIPT_FILENAME }}
+      - echo "Done"
+      - echo "Copying mkcert root CA cert"
+      - cmd: docker cp {{ .CA_CERT_DIR }}/rootCA.pem {{ .CONTAINER_NAME }}:{{ .DESTINATION_DIR }}/{{ .CERT_NAME }}
+      - echo "Done"
+      - echo "Adding mkcert to trust store in container"
+      - cmd: docker exec --user root {{ .CONTAINER_NAME }} sh {{ .DESTINATION_DIR }}/{{ .SCRIPT_FILENAME }}
+      - echo "Done"
+
   generate-certs:
     desc: "Generate certificates"
     deps: [_mkcert-install]

--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,16 @@ task copy-ca-cert-to-container CONTAINER_NAME=your-container-name
 
 Now you will be able to send requests via https to `*.blumilk.local.env` domains or others generated via mkcert.
 
+## HTTPS in browsers in containers
+
+To use self-signed certs in browsers, we have to add root CA (from mkcert) to the trust store.
+
+To do it, run the container from which you want to add mkcert root CA to the trust store. \
+Use container name or ID.
+```shell
+task copy-ca-cert-to-trust-store-in-container CONTAINER_NAME=your-container-name
+```
+
 ### More on mkcert
 
 - github: https://github.com/FiloSottile/mkcert

--- a/scripts/add-ca-to-trust-store.sh
+++ b/scripts/add-ca-to-trust-store.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# https://superuser.com/a/1717924
+### Script installs root.cert.pem to certificate trust store of applications using NSS
+### (e.g. Firefox, Thunderbird, Chromium)
+### Mozilla uses cert8, Chromium and Chrome use cert9
+
+###
+### Requirement: apt install libnss3-tools
+###
+
+###
+### CA file to install (CUSTOMIZE!)
+###
+
+certfile="blumilk-environment-mkcert-root-ca-cert.pem"
+certname="My Root CA"
+
+###
+### For cert8 (legacy - DBM)
+###
+
+for certDB in $(find ~/ -name "cert8.db")
+do
+    certdir=$(dirname ${certDB});
+    certutil -A -n "${certname}" -t "TCu,Cu,Tu" -i ${certfile} -d dbm:${certdir}
+done
+
+###
+### For cert9 (SQL)
+###
+
+for certDB in $(find ~/ -name "cert9.db")
+do
+    certdir=$(dirname ${certDB});
+    certutil -A -n "${certname}" -t "TCu,Cu,Tu" -i ${certfile} -d sql:${certdir}
+done


### PR DESCRIPTION
This pull request introduces functionality to add a self-signed root CA certificate (generated by `mkcert`) to the trust store of applications running within a container. The changes include a new task in the `Taskfile.yml`, a supporting script, and documentation updates to guide users on how to use this feature.

### New task for managing CA certificates in containers:

* **`Taskfile.yml`:** Added a new task `copy-ca-cert-to-trust-store-in-container` to copy the `mkcert` root CA certificate and a helper script into a container, and execute the script to add the certificate to the trust store.

### Documentation updates:

* **`readme.md`:** Added a new section explaining how to use the `copy-ca-cert-to-trust-store-in-container` task to enable HTTPS in browsers within containers.

### Supporting script:

* **`scripts/add-ca-to-trust-store.sh`:** Introduced a Bash script to install the `mkcert` root CA certificate into the trust store of applications using NSS (e.g., Firefox, Chromium). The script handles both legacy `cert8.db` and modern `cert9.db` formats.

---

## Background:

Selenium shows cert error during browser tests.
Adding mkcert root CA to trust store in the Selenium container fix this issue.