### PR TITLE
- Adjust readme and required task versions

### DIFF
--- a/Taskfile-init.yml
+++ b/Taskfile-init.yml
@@ -1,5 +1,5 @@
 # https://taskfile.dev
-version: "3.42.1"
+version: "3"
 
 silent: true
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,5 +1,5 @@
 # https://taskfile.dev
-version: "3.42.1"
+version: "3"
 
 silent: true
 

--- a/readme.md
+++ b/readme.md
@@ -9,26 +9,16 @@ This repo contains default Blumilk Traefik configuration for local development e
 - one free port on host system (default 301)
 - [Docker](https://docs.docker.com/engine/install/)
 - [Docker Compose (version 2)](https://docs.docker.com/compose/install/)
-- [Taskfile](https://taskfile.dev/) (min. version 3.42.1)
+- [Taskfile](https://taskfile.dev/) (min. version 3)
 
 # Installation
 
 ---
 ## Taskfile setup
-### Linux
+### Installation
 
-If you don't have Task binary installed, you can install it by running command below. \
-If you don't want to install to `/usr/local/bin` (dir for all users in the system) change `-b` flag value. \
-Be sure that provided path is in system $PATH, that binary will be available in the terminal. 
-To check system paths type `$PATH` in the terminal.
+Installation methods: https://taskfile.dev/installation
 
-```shell
-sudo sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b /usr/local/bin v3.42.1
-```
-_-b sets bindir or installation directory, Defaults to ./bin_ \
-_-d turns on debug logging_
-
-Other installation methods: https://taskfile.dev/installation \
 GitHub: https://github.com/go-task/task \
 Taskfile releases: https://github.com/go-task/task/releases
 
@@ -88,6 +78,7 @@ If you want to re-initialize, run `task init --force` or remove `.initialized` f
 WARNING, these files will be replaced during initialization:
 - ./traefik/config/static/traefik.yml
 - ./traefik/config/dynamic/certificates.yml
+- ./traefik/config/dynamic/middlewares.yml
 - ./portainer/portainer-admin-password-file - if Portainer has been created, changing password in this file won't change admin password. To change password you need to remove portainer container, volume and recreate it or check Portianer [docs](https://docs.portainer.io/advanced/reset-admin.)
 - ./dns/dnsmasq/dnsmasq.d/blumilk-local-environment.conf
 - ./dns/systemd/resolved.conf.d/blumilk-local-environment.conf


### PR DESCRIPTION
This pull request includes updates to the `Taskfile` version requirement, revisions to the documentation in `readme.md`, and the addition of a new file to the initialization warning list.

### Taskfile updates:
* `Taskfile-init.yml` and `Taskfile.yml`: Updated the `Taskfile` version from `3.42.1` to `3` to align with the latest requirements. [[1]](diffhunk://#diff-1aecc79a2fee6ca62da4e1d28927d990993be9b6b7493d14dc2d4f46df2ac6ccL2-R2) [[2]](diffhunk://#diff-cd2d359855d0301ce190f1ec3b4c572ea690c83747f6df61c9340720e3d2425eL2-R2)

### Documentation revisions:
* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L12-L31): Updated the minimum required `Taskfile` version from `3.42.1` to `3` and simplified installation instructions by replacing the Linux-specific installation guide with a general link to the Taskfile installation methods.

### Initialization warning updates:
* [`readme.md`](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R81): Added `./traefik/config/dynamic/middlewares.yml` to the list of files that will be replaced during initialization.