### PR TITLE
support Docker v29

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @blumilksoftware/blumilk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ volumes:
 
 services:
   traefik-proxy-service:
-    image: traefik:v3.5.3@sha256:84eb6c0e67c99fa026bf1bf4b0afd9ad44350d375b4ebc5049c5f70543a729d6
+    image: traefik:v3.6.2
     container_name: ${TRAEFIK_CONTAINER_NAME}
     restart: unless-stopped
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - ./traefik/certs:/certs
 
   portainer-service:
-    image: portainer/portainer-ce:lts@sha256:264443d4063e0f2633f3ba210ccd69aacf07344dfc792128131dec8963df0f0a
+    image: portainer/portainer-ce:2.36.0
     container_name: ${PORTAINER_CONTAINER_NAME}
     restart: unless-stopped
     command:


### PR DESCRIPTION
This PR updates Traefik and Portainer versions to support Docker engine v29.

Docker info:
- https://www.docker.com/blog/docker-engine-version-29/
- https://docs.docker.com/engine/release-notes/29/

Traefik (fixed in 3.6.1):
- https://github.com/traefik/traefik/issues/12253
- https://github.com/traefik/traefik/pull/12256
- https://github.com/traefik/traefik/releases/tag/v3.6.1

Portainer: (fixed in 2.33.5)
- https://github.com/portainer/portainer/issues/12934
- https://github.com/portainer/portainer/issues/12925
- https://github.com/portainer/portainer/releases/tag/2.33.5