### PR TITLE
- Exclude one-off compose containers from Traefik routing

### DIFF
--- a/traefik/config/static/traefik.yml.example
+++ b/traefik/config/static/traefik.yml.example
@@ -28,4 +28,4 @@ providers:
     docker:
         network: TRAEFIK_NETWORK_PLACEHOLDER
         exposedByDefault: false
-        constraints: "Label(`TRAEFIK_CUSTOM_LABEL_PLACEHOLDER`,`true`)"
+        constraints: "Label(`TRAEFIK_CUSTOM_LABEL_PLACEHOLDER`,`true`) && !Label(`com.docker.compose.oneoff`,`True`)"


### PR DESCRIPTION
## Problem

`docker compose run` containers inherit their service's labels, including `traefik.blumilk.local.environment`, so Traefik registers them as extra backends for that service's routers. Such one-off containers serve no HTTP (e.g. JetBrains docker-compose interpreters spawn them to run `node`/`php` for the language service), so requests round-robined to them return intermittent **502s / CORS failures** on the real service.

## Fix

Docker stamps one-off (`compose run`) containers with `com.docker.compose.oneoff=True` (normal `up` services are `False`). Adding `&& !Label(com.docker.compose.oneoff, True)` to the docker provider constraint makes Traefik ignore them while still routing to the real, long-lived service containers.

```diff
- constraints: "Label(`...`,`true`)"
+ constraints: "Label(`...`,`true`) && !Label(`com.docker.compose.oneoff`,`True`)"
```

Template-only change (`traefik.yml.example`); placeholders preserved.

## Verification

With a live `compose run` container present, the real service went from ~50% 502 flapping to **12/12 → 200**. Normal `up` services are unaffected (they carry `oneoff=False`), so it's backwards-compatible.